### PR TITLE
Obtain hostname from registry instead of environment variables

### DIFF
--- a/Suborner/Core/SubornerContext.cs
+++ b/Suborner/Core/SubornerContext.cs
@@ -84,7 +84,6 @@ namespace Suborner.Core
             // Didn't add special characters sanitization if you ever want to experiment with them :)
             if (User.Username.Equals("<HOSTNAME>$"))
             {
-                // TODO: Retrieve this from registry
                 Logger.PrintInfo("Retrieving hostname");
                 User.Username = RegistryManager.GetHostname() + "$";
                 return;

--- a/Suborner/Core/SubornerContext.cs
+++ b/Suborner/Core/SubornerContext.cs
@@ -86,7 +86,7 @@ namespace Suborner.Core
             {
                 // TODO: Retrieve this from registry
                 Logger.PrintInfo("Retrieving hostname");
-                User.Username = System.Environment.GetEnvironmentVariable("COMPUTERNAME") + "$";
+                User.Username = RegistryManager.GetHostname() + "$";
                 return;
             }
             if (!User.Username.EndsWith("$"))

--- a/Suborner/Interop/Natives.cs
+++ b/Suborner/Interop/Natives.cs
@@ -432,6 +432,21 @@ namespace Suborner
             AllAccess = 0x000f003f
         }
 
+        [Flags]
+        public enum DwFlags
+        {
+            RRF_RT_ANY = 0x0000FFFF,
+            RRF_RT_DWORD = 0x00000018,
+            RRF_RT_QWORD = 0x00000048,
+            RRF_RT_REG_BINARY = 0x00000008,
+            RRF_RT_REG_DWORD = 0x00000010,
+            RRF_RT_REG_EXPAND_SZ = 0x00000004,
+            RRF_RT_REG_MULTI_SZ = 0x00000020,
+            RRF_RT_REG_NONE = 0x00000001,
+            RRF_RT_REG_QWORD = 0x00000040,
+            RRF_RT_REG_SZ = 0x00000002
+        }
+
         public enum RegResult
         {
             CreatedNewKey = 0x00000001,
@@ -483,9 +498,9 @@ namespace Suborner
             UIntPtr hkey, 
             string lpSubKey, 
             string lpValue, 
-            uint dwFlags, 
-            out uint pdwType, 
-            UIntPtr pvData, 
+            DwFlags dwFlags, 
+            out uint pdwType,
+            byte[] pvData, 
             ref Int32 pcbData);
 
         [DllImport("advapi32.dll", SetLastError = true)]

--- a/Suborner/Module/RegistryManager.cs
+++ b/Suborner/Module/RegistryManager.cs
@@ -22,6 +22,7 @@ namespace Suborner
         const string SAM_DOMAINS_ACCOUNT_KEYPATH = @"SAM\SAM\Domains\Account\";
         const string SAM_DOMAINS_ACCOUNT_USERS_KEYPATH = @"SAM\SAM\Domains\Account\Users\";
         const string LSA_CURRENTCONTROLSET_CONTROL_KEYPATH = @"SYSTEM\CurrentControlSet\Control\Lsa\";
+        const string SYSTEM_HOSTNAME_KEYPATH = @"SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\";
 
         const int SYSKEY_LENGTH = 16;
         static readonly string[] SYSKEY_NAMES = { "JD", "Skew1", "GBG", "Data" };
@@ -106,6 +107,18 @@ namespace Suborner
 
             F = FValue;
             V = VValue;
+        }
+
+        public static string GetHostname()
+        {
+            //TODO: Implement with API Calls
+            string hostname = null;
+
+            RegistryKey userKey = Registry.LocalMachine.OpenSubKey(SYSTEM_HOSTNAME_KEYPATH);
+            hostname = (string)userKey.GetValue("ComputerName");
+            userKey.Close();
+
+            return hostname;
         }
 
         public static void WriteNamesKey(string username, int rid)

--- a/Suborner/Module/RegistryManager.cs
+++ b/Suborner/Module/RegistryManager.cs
@@ -111,14 +111,25 @@ namespace Suborner
 
         public static string GetHostname()
         {
-            //TODO: Implement with API Calls
-            string hostname = null;
+            UIntPtr hKey = OpenRegKey("HKLM", SYSTEM_HOSTNAME_KEYPATH);
+            
+            int MAX_CLASS_DATA_SIZE = 16383;
+            uint valueType;
+            byte[] hostname = new byte[MAX_CLASS_DATA_SIZE];
 
-            RegistryKey userKey = Registry.LocalMachine.OpenSubKey(SYSTEM_HOSTNAME_KEYPATH);
-            hostname = (string)userKey.GetValue("ComputerName");
-            userKey.Close();
+            RegGetValue(hKey, "", "ComputerName", DwFlags.RRF_RT_REG_SZ, out valueType, hostname, ref MAX_CLASS_DATA_SIZE);
+            CloseRegKey(hKey);
 
-            return hostname;
+            StringBuilder hostnameStringBuilder = new StringBuilder();
+
+            for (int i = 0; i < hostname.Length; i += 2)
+            {
+                char currentChar = BitConverter.ToChar(hostname, i);
+                if (currentChar == '\0') break;
+                hostnameStringBuilder.Append(currentChar);
+            }
+
+            return hostnameStringBuilder.ToString();
         }
 
         public static void WriteNamesKey(string username, int rid)


### PR DESCRIPTION
Obtaining hostname from SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\ registry, instead of environment variable, made using WinAPI calls